### PR TITLE
Integrate Assembly Management Components

### DIFF
--- a/src/app/components/assemblies/assemblies.component.html
+++ b/src/app/components/assemblies/assemblies.component.html
@@ -44,51 +44,14 @@
           Agregar Nueva Pregunta
         </button>
 
-        <mat-card class="bg-white rounded-xl shadow-sm border border-slate-200 overflow-hidden flex-1">
-          <div class="p-4 border-b border-slate-100 bg-slate-50 flex justify-between items-center">
-            <h3 class="font-bold text-slate-700">Historial de Preguntas</h3>
-            <span class="text-xs font-medium text-slate-400 bg-slate-200 px-2 py-0.5 rounded">{{ surveysHistory.length }} Total</span>
-          </div>
-          <div class="p-4 space-y-4 sidebar-scroll max-h-[500px] overflow-y-auto">
-            <!-- Historical Question Card -->
-            <div *ngFor="let survey of surveysHistory" class="p-4 border border-slate-100 rounded-lg hover:bg-slate-50 transition-colors">
-              <p class="text-sm font-medium text-slate-800 mb-2">{{ survey.question }}</p>
-              <div class="flex justify-between items-end">
-                <div>
-                  <span class="text-xs text-slate-400 block mb-1">Opción más votada:</span>
-                  <span class="text-sm font-bold text-emerald-600">{{ survey.mostVotedOption }}</span>
-                </div>
-                <div class="text-right">
-                  <span class="text-xs font-bold text-slate-700 block">{{ survey.mostVotedVotes }} Votos</span>
-                  <span class="text-[10px] text-slate-400">{{ survey.mostVotedCoefficient }}% Coeficiente</span>
-                </div>
-              </div>
-            </div>
-
-            <div *ngIf="surveysHistory.length === 0" class="text-center py-8">
-              <p class="text-sm text-slate-400">No hay historial de preguntas.</p>
-            </div>
-          </div>
-        </mat-card>
+        <app-survey-history class="flex-1"></app-survey-history>
       </div>
     </aside>
     <!-- END: QuestionsSidebar -->
 
     <!-- BEGIN: ActiveSurveyInfo (Now on the right/center) -->
     <section class="lg:col-span-2" data-purpose="current-survey-status">
-      <mat-card class="bg-white rounded-xl shadow-sm border border-slate-200 overflow-hidden h-full">
-        <div class="bg-slate-50 border-b border-slate-200 p-6">
-          <div class="flex items-center justify-between">
-            <div>
-              <h2 class="text-xl font-bold text-slate-800">Encuesta Activa / Actual</h2>
-              <p class="text-sm text-slate-500">El detalle de la encuesta se mostrará aquí.</p>
-            </div>
-          </div>
-        </div>
-        <div class="p-6">
-          <p class="text-slate-400 italic">No hay encuesta activa en este momento o se cargará el componente de encuesta actual.</p>
-        </div>
-      </mat-card>
+      <app-current-survey [totalRegisteredUsers]="stats.totalUnits"></app-current-survey>
     </section>
     <!-- END: ActiveSurveyInfo -->
   </div>

--- a/src/app/components/assemblies/assemblies.component.spec.ts
+++ b/src/app/components/assemblies/assemblies.component.spec.ts
@@ -1,22 +1,55 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AssembliesComponent } from './assemblies.component';
-import { MatDialog } from '@angular/material/dialog';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { of } from 'rxjs';
+import { EventEmitter, Component } from '@angular/core';
+import { AssemblyService } from '@services/data/assembly.service';
+import { AddQuestionComponent } from '@components/asambleas/add-question/add-question.component';
+import { SurveyHistoryComponent } from '@components/asambleas/survey-history/survey-history.component';
+import { CurrentSurveyComponent } from '@components/asambleas/current-survey/current-survey.component';
+
+@Component({ selector: 'app-add-question', standalone: true, template: '' })
+class MockAddQuestionComponent {
+  closed = new EventEmitter<void>();
+}
+
+@Component({ selector: 'app-survey-history', standalone: true, template: '' })
+class MockSurveyHistoryComponent {}
+
+@Component({ selector: 'app-current-survey', standalone: true, template: '', inputs: ['totalRegisteredUsers'] })
+class MockCurrentSurveyComponent {
+  totalRegisteredUsers: number = 0;
+}
 
 describe('AssembliesComponent', () => {
   let component: AssembliesComponent;
   let fixture: ComponentFixture<AssembliesComponent>;
   let dialogSpy: jasmine.SpyObj<MatDialog>;
+  let assemblyServiceSpy: jasmine.SpyObj<AssemblyService>;
 
   beforeEach(async () => {
     dialogSpy = jasmine.createSpyObj('MatDialog', ['open']);
+    assemblyServiceSpy = jasmine.createSpyObj('AssemblyService', ['getAllSurveis', 'getVotes', 'getAttendees', 'getCoefficient']);
+
+    assemblyServiceSpy.getAllSurveis.and.returnValue(Promise.resolve([]));
 
     await TestBed.configureTestingModule({
       imports: [AssembliesComponent, NoopAnimationsModule],
       providers: [
-        { provide: MatDialog, useValue: dialogSpy }
+        { provide: MatDialog, useValue: dialogSpy },
+        { provide: AssemblyService, useValue: assemblyServiceSpy }
       ]
-    }).compileComponents();
+    })
+    .overrideComponent(AssembliesComponent, {
+      remove: {
+        imports: [AddQuestionComponent, SurveyHistoryComponent, CurrentSurveyComponent]
+      },
+      add: {
+        imports: [MockAddQuestionComponent, MockSurveyHistoryComponent, MockCurrentSurveyComponent]
+      }
+    })
+    .compileComponents();
 
     fixture = TestBed.createComponent(AssembliesComponent);
     component = fixture.componentInstance;
@@ -39,9 +72,25 @@ describe('AssembliesComponent', () => {
     expect(component.surveysHistory[0].question).toBe('¿Aprueba el presupuesto para el año 2024?');
   });
 
-  it('should log when opening create survey popup', () => {
-    const consoleSpy = spyOn(console, 'log');
+  it('should open dialog when calling openCreateSurveyPopup', () => {
+    const closedEmitter = new EventEmitter<void>();
+    const dialogRefSpy = {
+      close: jasmine.createSpy('close'),
+      componentInstance: {
+        closed: closedEmitter
+      }
+    };
+
+    dialogSpy.open.and.returnValue(dialogRefSpy as any);
+
     component.openCreateSurveyPopup();
-    expect(consoleSpy).toHaveBeenCalledWith('Opening create survey popup...');
+
+    expect(dialogSpy.open).toHaveBeenCalled();
+
+    spyOn(component, 'loadSurveysHistory');
+    closedEmitter.emit();
+
+    expect(dialogRefSpy.close).toHaveBeenCalled();
+    expect(component.loadSurveysHistory).toHaveBeenCalled();
   });
 });

--- a/src/app/components/assemblies/assemblies.component.ts
+++ b/src/app/components/assemblies/assemblies.component.ts
@@ -5,6 +5,9 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatDialogModule, MatDialog } from '@angular/material/dialog';
 import { AssemblyStats, Survey } from '@app/model/assembly.model';
+import { AddQuestionComponent } from '@components/asambleas/add-question/add-question.component';
+import { SurveyHistoryComponent } from '@components/asambleas/survey-history/survey-history.component';
+import { CurrentSurveyComponent } from '@components/asambleas/current-survey/current-survey.component';
 
 @Component({
   selector: 'app-assemblies',
@@ -14,7 +17,10 @@ import { AssemblyStats, Survey } from '@app/model/assembly.model';
     MatCardModule,
     MatButtonModule,
     MatIconModule,
-    MatDialogModule
+    MatDialogModule,
+    AddQuestionComponent,
+    SurveyHistoryComponent,
+    CurrentSurveyComponent
   ],
   templateUrl: './assemblies.component.html',
   styleUrls: ['./assemblies.component.css']
@@ -85,8 +91,13 @@ export class AssembliesComponent implements OnInit {
   }
 
   openCreateSurveyPopup(): void {
-    // Popup creation logic will be implemented in future steps/agents
-    console.log('Opening create survey popup...');
-    // Example: this.dialog.open(CreateSurveyComponent);
+    const dialogRef = this.dialog.open(AddQuestionComponent, {
+      width: '500px'
+    });
+
+    dialogRef.componentInstance.closed.subscribe(() => {
+      dialogRef.close();
+      this.loadSurveysHistory();
+    });
   }
 }

--- a/src/app/components/links/links.component.html
+++ b/src/app/components/links/links.component.html
@@ -150,4 +150,25 @@ Si requiere asistencia adicional o tiene alguna pregunta, no dude en ponerse en 
 		</mat-card-actions>
 	</mat-card>
 }
+@if(showAssembliesCard){
+	<mat-card appearance="outlined">
+		<mat-card-header>
+			<mat-card-title>
+				<span>Asambleas</span>
+			</mat-card-title>
+		</mat-card-header>
+		<mat-card-content>
+			<p>
+				Gestión de asambleas, preguntas y resultados de encuestas en tiempo real para la copropiedad.
+			</p>
+		</mat-card-content>
+		<mat-card-actions align="end">
+			<a routerLink="/main/assemblies"
+				mat-stroked-button>
+				<mat-icon>groups</mat-icon>
+				ir
+			</a>
+		</mat-card-actions>
+	</mat-card>
+}
 </div>

--- a/src/app/components/links/links.component.spec.ts
+++ b/src/app/components/links/links.component.spec.ts
@@ -1,14 +1,24 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { LinksComponent } from './links.component';
+import { RouterModule } from '@angular/router';
+import { provideRouter } from '@angular/router';
+import { DataService } from '@services/data/data.service';
 
 describe('LinksComponent', () => {
   let component: LinksComponent;
   let fixture: ComponentFixture<LinksComponent>;
+  let dataServiceSpy: jasmine.SpyObj<DataService>;
 
   beforeEach(async () => {
+    dataServiceSpy = jasmine.createSpyObj('DataService', ['getData']);
+    dataServiceSpy.getData.and.returnValue(Promise.resolve({ value: '' }));
+
     await TestBed.configureTestingModule({
-      imports: [LinksComponent]
+      imports: [LinksComponent],
+      providers: [
+        provideRouter([]),
+        { provide: DataService, useValue: dataServiceSpy }
+      ]
     })
     .compileComponents();
 
@@ -19,5 +29,13 @@ describe('LinksComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should show assemblies card', () => {
+    expect(component.showAssembliesCard).toBeTrue();
+    const compiled = fixture.nativeElement as HTMLElement;
+    const cardTitles = Array.from(compiled.querySelectorAll('mat-card-title span'));
+    const assembliesTitle = cardTitles.find(el => el.textContent?.includes('Asambleas'));
+    expect(assembliesTitle).toBeTruthy();
   });
 });

--- a/src/app/components/links/links.component.ts
+++ b/src/app/components/links/links.component.ts
@@ -5,12 +5,13 @@ import { MatButtonModule } from '@angular/material/button';
 import { DataService } from '@services/data/data.service';
 import { ResponseDefault } from '@app/model/response-default.model';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { RouterModule } from '@angular/router';
 
 
 @Component({
   selector: 'app-links',
   standalone: true,
-  imports: [MatCardModule, MatIcon, MatButtonModule, MatProgressSpinnerModule],
+  imports: [MatCardModule, MatIcon, MatButtonModule, MatProgressSpinnerModule, RouterModule],
   templateUrl: './links.component.html',
   styleUrl: './links.component.css'
 })
@@ -33,6 +34,7 @@ export class LinksComponent {
   showGeneralCard: Boolean = false
   showSuggestionBoxCard: Boolean = true
   showFAQAICard: Boolean = false
+  showAssembliesCard: boolean = true;
 
   constructor(public dataService: DataService) {
     this.waitBillingSpinner = true;


### PR DESCRIPTION
Integrated independent assembly components into a cohesive module accessible from the main links screen. Navigating to /main/assemblies now displays the attendance stats, survey history, and active survey results. A button allows opening the question creation popup.

---
*PR created automatically by Jules for task [12661745128251796761](https://jules.google.com/task/12661745128251796761) started by @nano871022*