### PR TITLE
Integrate Real Data and Fix Layout in Assemblies Page

### DIFF
--- a/src/app/components/asambleas/current-survey/current-survey.component.ts
+++ b/src/app/components/asambleas/current-survey/current-survey.component.ts
@@ -33,21 +33,21 @@ export class CurrentSurveyComponent implements OnInit, OnDestroy {
   constructor(private assemblyService: AssemblyService) {}
 
   ngOnInit(): void {
-    this.loadData();
+    this.loadData(true);
   }
 
-  async loadData(): Promise<void> {
-    await this.loadActiveSurvey();
-    await this.loadStats();
+  async loadData(refresh: boolean = false): Promise<void> {
+    await this.loadActiveSurvey(refresh);
+    await this.loadStats(refresh);
   }
 
   ngOnDestroy(): void {
     this.stopTimer();
   }
 
-  async loadActiveSurvey(): Promise<void> {
+  async loadActiveSurvey(refresh: boolean = false): Promise<void> {
     try {
-      const surveys = await this.assemblyService.getAllSurveis();
+      const surveys = await this.assemblyService.getAllSurveis(refresh);
       // In this version we only take the first one as "active" or "recently closed"
       this.activeSurvey = surveys.length > 0 ? surveys[0] : null;
 
@@ -67,11 +67,11 @@ export class CurrentSurveyComponent implements OnInit, OnDestroy {
     }
   }
 
-  async loadStats(): Promise<void> {
+  async loadStats(refresh: boolean = false): Promise<void> {
     if (!this.activeSurvey) return;
 
     try {
-      const votesData = await this.assemblyService.getVotes('active');
+      const votesData = await this.assemblyService.getVotes('active', refresh);
       this.receivedVotes = votesData.totalVotes || 0;
 
       this.calculateMissingAndPercentage();
@@ -124,7 +124,7 @@ export class CurrentSurveyComponent implements OnInit, OnDestroy {
     if (window.confirm('¿Está seguro de que desea cerrar la votación?')) {
       try {
         await this.assemblyService.closeVotes('active');
-        await this.loadData();
+        await this.loadData(true);
       } catch (error) {
         console.error('Error closing voting:', error);
       }
@@ -135,7 +135,7 @@ export class CurrentSurveyComponent implements OnInit, OnDestroy {
     if (window.confirm('¿Está seguro de que desea reiniciar la encuesta? Esta acción no se puede deshacer.')) {
       try {
         await this.assemblyService.restartSurvey('active');
-        await this.loadData();
+        await this.loadData(true);
       } catch (error) {
         console.error('Error restarting survey:', error);
       }

--- a/src/app/components/asambleas/survey-history/survey-history.component.ts
+++ b/src/app/components/asambleas/survey-history/survey-history.component.ts
@@ -24,18 +24,18 @@ export class SurveyHistoryComponent implements OnInit {
   constructor(private assemblyService: AssemblyService) { }
 
   ngOnInit(): void {
-    this.loadHistory();
+    this.loadHistory(true);
   }
 
-  async loadHistory(): Promise<void> {
+  async loadHistory(refresh: boolean = false): Promise<void> {
     try {
-      const surveys = await this.assemblyService.getAllSurveis();
+      const surveys = await this.assemblyService.getAllSurveis(refresh);
       // Transform and sort history (newest to oldest)
       this.history = surveys
         .map((s: any) => ({
           id: s.id,
           question: s.question,
-          mostVotedOption: s.mostVotedOption || (s.options && s.options.length > 0 ? s.options[0].text : 'N/A'),
+          mostVotedOption: s.mostVotedOption || (s.options && s.options.length > 0 ? s.options[0].value : 'N/A'),
           mostVotedCoefficient: s.mostVotedCoefficient || 0,
           timeUsed: s.timeUsed || '00:00',
           createDate: s.createDate || s.createdAt || new Date()

--- a/src/app/components/assemblies/assemblies.component.css
+++ b/src/app/components/assemblies/assemblies.component.css
@@ -68,3 +68,187 @@ mat-card {
 .btn-transition:active {
   transform: translateY(0);
 }
+
+/* Tailwind-like utility classes */
+.container {
+  width: 100%;
+}
+
+.mx-auto {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.px-4 {
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.py-8 {
+  padding-top: 2rem;
+  padding-bottom: 2rem;
+}
+
+.grid {
+  display: grid;
+}
+
+.grid-cols-1 {
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+.grid-cols-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.gap-4 {
+  gap: 1rem;
+}
+
+.gap-6 {
+  gap: 1.5rem;
+}
+
+.gap-8 {
+  gap: 2rem;
+}
+
+.mb-4 {
+  margin-bottom: 1rem;
+}
+
+.mb-8 {
+  margin-bottom: 2rem;
+}
+
+.flex {
+  display: flex;
+}
+
+.flex-col {
+  flex-direction: column;
+}
+
+.items-center {
+  align-items: center;
+}
+
+.justify-center {
+  justify-content: center;
+}
+
+.relative {
+  position: relative;
+}
+
+.absolute {
+  position: absolute;
+}
+
+.inset-0 {
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}
+
+.w-full {
+  width: 100%;
+}
+
+.w-48 {
+  width: 12rem;
+}
+
+.h-full {
+  height: 100%;
+}
+
+.h-48 {
+  height: 12rem;
+}
+
+@media (min-width: 1024px) {
+  .lg\:grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .lg\:col-span-1 {
+    grid-column: span 1 / span 1;
+  }
+
+  .lg\:col-span-2 {
+    grid-column: span 2 / span 2;
+  }
+}
+
+.bg-white {
+  background-color: #ffffff;
+}
+
+.p-6 {
+  padding: 1.5rem;
+}
+
+.rounded-xl {
+  border-radius: 0.75rem;
+}
+
+.shadow-sm {
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+}
+
+.shadow-md {
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+}
+
+.font-semibold {
+  font-weight: 600;
+}
+
+.font-bold {
+  font-weight: 700;
+}
+
+.uppercase {
+  text-transform: uppercase;
+}
+
+.tracking-wider {
+  letter-spacing: 0.05em;
+}
+
+.text-xs {
+  font-size: 0.75rem;
+  line-height: 1rem;
+}
+
+.text-sm {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+}
+
+.text-3xl {
+  font-size: 1.875rem;
+  line-height: 2.25rem;
+}
+
+.text-blue-600 {
+  color: #2563eb;
+}
+
+.text-slate-600 {
+  color: #475569;
+}
+
+.italic {
+  font-style: italic;
+}
+
+.gap-3 {
+  gap: 0.75rem;
+}
+
+.flex-1 {
+  flex: 1 1 0%;
+}

--- a/src/app/components/assemblies/assemblies.component.spec.ts
+++ b/src/app/components/assemblies/assemblies.component.spec.ts
@@ -64,15 +64,13 @@ describe('AssembliesComponent', () => {
   });
 
   it('should load stats on init', async () => {
-    await fixture.whenStable();
+    assemblyServiceSpy.getAttendees.and.returnValue(Promise.resolve({ attendanceCount: 142, totalUnits: 190, quorumPercentage: 74.7 }));
+    assemblyServiceSpy.getCoefficient.and.returnValue(Promise.resolve({ coefficientPercentage: 68.2 }));
+
+    await component.loadStats();
+
     expect(component.stats.attendanceCount).toBe(142);
     expect(component.stats.totalUnits).toBe(190);
-  });
-
-  it('should load surveys history on init', async () => {
-    await fixture.whenStable();
-    expect(component.surveysHistory.length).toBe(3);
-    expect(component.surveysHistory[0].question).toBe('¿Aprueba el presupuesto para el año 2024?');
   });
 
   it('should open dialog when calling openCreateSurveyPopup', () => {
@@ -90,10 +88,15 @@ describe('AssembliesComponent', () => {
 
     expect(dialogSpy.open).toHaveBeenCalled();
 
-    spyOn(component, 'loadSurveysHistory');
+    spyOn(component, 'loadStats');
+    component.historyComponent = { loadHistory: jasmine.createSpy('loadHistory') } as any;
+    component.currentSurveyComponent = { loadData: jasmine.createSpy('loadData') } as any;
+
     closedEmitter.emit();
 
     expect(dialogRefSpy.close).toHaveBeenCalled();
-    expect(component.loadSurveysHistory).toHaveBeenCalled();
+    expect(component.loadStats).toHaveBeenCalled();
+    expect(component.historyComponent.loadHistory).toHaveBeenCalledWith(true);
+    expect(component.currentSurveyComponent.loadData).toHaveBeenCalledWith(true);
   });
 });

--- a/src/app/components/assemblies/assemblies.component.ts
+++ b/src/app/components/assemblies/assemblies.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
 import { MatButtonModule } from '@angular/material/button';
@@ -8,6 +8,7 @@ import { AssemblyStats, Survey } from '@app/model/assembly.model';
 import { AddQuestionComponent } from '@components/asambleas/add-question/add-question.component';
 import { SurveyHistoryComponent } from '@components/asambleas/survey-history/survey-history.component';
 import { CurrentSurveyComponent } from '@components/asambleas/current-survey/current-survey.component';
+import { AssemblyService } from '@app/services/data/assembly.service';
 
 @Component({
   selector: 'app-assemblies',
@@ -26,6 +27,9 @@ import { CurrentSurveyComponent } from '@components/asambleas/current-survey/cur
   styleUrls: ['./assemblies.component.css']
 })
 export class AssembliesComponent implements OnInit {
+  @ViewChild(SurveyHistoryComponent) historyComponent!: SurveyHistoryComponent;
+  @ViewChild(CurrentSurveyComponent) currentSurveyComponent!: CurrentSurveyComponent;
+
   stats: AssemblyStats = {
     attendanceCount: 0,
     totalUnits: 0,
@@ -33,61 +37,33 @@ export class AssembliesComponent implements OnInit {
     coefficientPercentage: 0,
     minRequiredPercentage: 51
   };
-  surveysHistory: Survey[] = [];
 
   constructor(
-    private dialog: MatDialog
+    private dialog: MatDialog,
+    private assemblyService: AssemblyService
   ) {}
 
   ngOnInit(): void {
     this.loadStats();
-    this.loadSurveysHistory();
   }
 
   async loadStats(): Promise<void> {
-    // In a real scenario, this would call a service.
-    // Mocking the data here as requested.
-    this.stats = {
-      attendanceCount: 142,
-      totalUnits: 190,
-      quorumPercentage: 74.7,
-      coefficientPercentage: 68.2,
-      minRequiredPercentage: 51
-    };
-  }
+    try {
+      const [attendees, coefficient] = await Promise.all([
+        this.assemblyService.getAttendees(true),
+        this.assemblyService.getCoefficient(true)
+      ]);
 
-  async loadSurveysHistory(): Promise<void> {
-    // In a real scenario, this would call a service.
-    // Mocking the history list here.
-    this.surveysHistory = [
-      {
-        id: '1',
-        question: '¿Aprueba el presupuesto para el año 2024?',
-        status: 'CLOSED',
-        createdAt: new Date(Date.now() - 3600000).toISOString(),
-        mostVotedOption: 'Sí',
-        mostVotedVotes: 120,
-        mostVotedCoefficient: 58.5
-      },
-      {
-        id: '2',
-        question: '¿Desea cambiar la empresa de seguridad?',
-        status: 'CLOSED',
-        createdAt: new Date(Date.now() - 7200000).toISOString(),
-        mostVotedOption: 'No',
-        mostVotedVotes: 85,
-        mostVotedCoefficient: 42.3
-      },
-      {
-        id: '3',
-        question: '¿Está de acuerdo con la remodelación del lobby?',
-        status: 'CLOSED',
-        createdAt: new Date(Date.now() - 10800000).toISOString(),
-        mostVotedOption: 'Sí',
-        mostVotedVotes: 98,
-        mostVotedCoefficient: 51.2
-      }
-    ];
+      this.stats = {
+        attendanceCount: attendees.attendanceCount || 0,
+        totalUnits: attendees.totalUnits || 0,
+        quorumPercentage: attendees.quorumPercentage || 0,
+        coefficientPercentage: coefficient.coefficientPercentage || 0,
+        minRequiredPercentage: 51
+      };
+    } catch (error) {
+      console.error('Error loading assembly stats:', error);
+    }
   }
 
   openCreateSurveyPopup(): void {
@@ -97,7 +73,13 @@ export class AssembliesComponent implements OnInit {
 
     dialogRef.componentInstance.closed.subscribe(() => {
       dialogRef.close();
-      this.loadSurveysHistory();
+      this.loadStats();
+      if (this.historyComponent) {
+        this.historyComponent.loadHistory(true);
+      }
+      if (this.currentSurveyComponent) {
+        this.currentSurveyComponent.loadData(true);
+      }
     });
   }
 }

--- a/src/app/services/data/assembly.service.spec.ts
+++ b/src/app/services/data/assembly.service.spec.ts
@@ -31,7 +31,7 @@ describe('AssemblyService', () => {
 
     await service.getAllSurveis();
 
-    expect(httpClientSpy.fetchAuth).toHaveBeenCalledWith('/api/assembly/all');
+    expect(httpClientSpy.fetchAuth).toHaveBeenCalledWith('/api/assembly/all', undefined, false);
   });
 
   it('should call getVotes endpoint with id', async () => {
@@ -43,7 +43,7 @@ describe('AssemblyService', () => {
 
     await service.getVotes(id);
 
-    expect(httpClientSpy.fetchAuth).toHaveBeenCalledWith(`/api/assembly/votes?id=${id}`);
+    expect(httpClientSpy.fetchAuth).toHaveBeenCalledWith(`/api/assembly/votes?id=${id}`, undefined, false);
   });
 
   it('should call getAttendees endpoint', async () => {
@@ -54,7 +54,7 @@ describe('AssemblyService', () => {
 
     await service.getAttendees();
 
-    expect(httpClientSpy.fetchAuth).toHaveBeenCalledWith('/api/assembly/attendees');
+    expect(httpClientSpy.fetchAuth).toHaveBeenCalledWith('/api/assembly/attendees', undefined, false);
   });
 
   it('should call getCoefficient endpoint', async () => {
@@ -65,7 +65,7 @@ describe('AssemblyService', () => {
 
     await service.getCoefficient();
 
-    expect(httpClientSpy.fetchAuth).toHaveBeenCalledWith('/api/assembly/coefficient');
+    expect(httpClientSpy.fetchAuth).toHaveBeenCalledWith('/api/assembly/coefficient', undefined, false);
   });
 
   it('should call restartSurvey endpoint with id', async () => {

--- a/src/app/services/data/assembly.service.ts
+++ b/src/app/services/data/assembly.service.ts
@@ -9,23 +9,23 @@ export class AssemblyService {
 
   constructor(private http: HttpClientService) { }
 
-  getAllSurveis(): Promise<Survey[]> {
-    return this.http.fetchAuth('/api/assembly/all')
+  getAllSurveis(refresh: boolean = false): Promise<Survey[]> {
+    return this.http.fetchAuth('/api/assembly/all', undefined, refresh)
       .then(response => response.json());
   }
 
-  getVotes(id: string): Promise<any> {
-    return this.http.fetchAuth(`/api/assembly/votes?id=${id}`)
+  getVotes(id: string, refresh: boolean = false): Promise<any> {
+    return this.http.fetchAuth(`/api/assembly/votes?id=${id}`, undefined, refresh)
       .then(response => response.json());
   }
 
-  getAttendees(): Promise<any> {
-    return this.http.fetchAuth('/api/assembly/attendees')
+  getAttendees(refresh: boolean = false): Promise<any> {
+    return this.http.fetchAuth('/api/assembly/attendees', undefined, refresh)
       .then(response => response.json());
   }
 
-  getCoefficient(): Promise<any> {
-    return this.http.fetchAuth('/api/assembly/coefficient')
+  getCoefficient(refresh: boolean = false): Promise<any> {
+    return this.http.fetchAuth('/api/assembly/coefficient', undefined, refresh)
       .then(response => response.json());
   }
 


### PR DESCRIPTION
The assemblies page now uses real data from the AssemblyService instead of hardcoded mock values. The statistics graphics (Attendance and Representation) are now correctly aligned side-by-side. Furthermore, the page now properly reloads its content (statistics, history, and active survey) whenever a new question is added through the popup, or when administrative actions like closing or restarting a survey are performed. Unit tests have been updated to reflect these changes and ensure continued reliability.

---
*PR created automatically by Jules for task [5062205266171804487](https://jules.google.com/task/5062205266171804487) started by @nano871022*